### PR TITLE
net-misc/iputils: update 99999999 to match 20160308

### DIFF
--- a/net-misc/iputils/iputils-99999999.ebuild
+++ b/net-misc/iputils/iputils-99999999.ebuild
@@ -6,15 +6,17 @@
 # them in a tarball on our mirrors.  This avoids ugly issues while
 # building stages, and when the jade/sgml packages are broken (which
 # seems to be more common than would be nice).
+# Required packages for doc generation:
+# app-text/docbook-sgml-utils
 
 EAPI=5
 
 inherit flag-o-matic eutils toolchain-funcs fcaps
 if [[ ${PV} == "99999999" ]] ; then
-	EGIT_REPO_URI="git://www.linux-ipv6.org/gitroot/iputils"
-	inherit git-2
+	EGIT_REPO_URI="https://github.com/iputils/iputils.git"
+	inherit git-r3
 else
-	SRC_URI="http://www.skbuff.net/iputils/iputils-s${PV}.tar.bz2
+	SRC_URI="https://github.com/iputils/iputils/archive/s${PV}.tar.gz -> ${P}.tar.gz
 		https://dev.gentoo.org/~polynomial-c/iputils-s${PV}-manpages.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~ppc-aix ~amd64-linux ~x86-linux"
 fi
@@ -24,13 +26,14 @@ HOMEPAGE="https://wiki.linuxfoundation.org/networking/iputils"
 
 LICENSE="BSD-4"
 SLOT="0"
-IUSE="arping caps clockdiff doc gcrypt idn ipv6 libressl rarpd rdisc SECURITY_HAZARD ssl static tftpd tracepath traceroute"
+IUSE="arping caps clockdiff doc gcrypt idn ipv6 libressl nettle +openssl rarpd rdisc SECURITY_HAZARD ssl static tftpd tracepath traceroute"
 
 LIB_DEPEND="caps? ( sys-libs/libcap[static-libs(+)] )
 	idn? ( net-dns/libidn[static-libs(+)] )
 	ipv6? ( ssl? (
 		gcrypt? ( dev-libs/libgcrypt:0=[static-libs(+)] )
-		!gcrypt? (
+		nettle? ( dev-libs/nettle[static-libs(+)] )
+		openssl? (
 			!libressl? ( dev-libs/openssl:0[static-libs(+)] )
 			libressl? ( dev-libs/libressl[static-libs(+)] )
 		)
@@ -51,42 +54,45 @@ if [[ ${PV} == "99999999" ]] ; then
 	"
 fi
 
+REQUIRED_USE="ipv6? ( ssl? ( ^^ ( gcrypt nettle openssl ) ) )"
+
 S=${WORKDIR}/${PN}-s${PV}
 
 PATCHES=(
-	"${FILESDIR}"/021109-uclibc-no-ether_ntohost.patch
-	"${FILESDIR}"/${PN}-99999999-openssl.patch #335436
-	"${FILESDIR}"/${PN}-99999999-tftpd-syslog.patch
-	"${FILESDIR}"/${PN}-20121221-makefile.patch
-	"${FILESDIR}"/${PN}-20121221-parallel-doc.patch
-	"${FILESDIR}"/${PN}-20121221-strtod.patch #472592
+	"${FILESDIR}/021109-uclibc-no-ether_ntohost.patch"
 )
 
 src_prepare() {
-	use SECURITY_HAZARD && PATCHES+=( "${FILESDIR}"/${PN}-20071127-nonroot-floodping.patch )
-	epatch "${PATCHES[@]}"
+	epatch ${PATCHES[@]}
+	use SECURITY_HAZARD && epatch "${FILESDIR}"/${PN}-20150815-nonroot-floodping.patch
 }
 
 src_configure() {
 	use static && append-ldflags -static
 
-	IPV4_TARGETS=(
+	TARGETS=(
 		ping
 		$(for v in arping clockdiff rarpd rdisc tftpd tracepath ; do usev ${v} ; done)
 	)
-	IPV6_TARGETS=(
-		ping6
-		$(usex tracepath 'tracepath6' '')
-		$(usex traceroute 'traceroute6' '')
-	)
-	use ipv6 || IPV6_TARGETS=()
-}
+	if use ipv6 ; then
+		TARGETS+=(
+			$(usex tracepath 'tracepath6' '')
+			$(usex traceroute 'traceroute6' '')
+		)
+	fi
 
-ldflag_resolv() {
-	# See if the system includes a libresolv. #584132
-	echo "main(){}" > "${T}"/resolv.c
-	if ${CC} ${CFLAGS} ${LDFLAGS} "${T}"/resolv.c -lresolv -o "${T}"/resolv 2>/dev/null ; then
-		echo -lresolv
+	myconf=(
+		USE_CRYPTO=no
+		USE_GCRYPT=no
+		USE_NETTLE=no
+	)
+
+	if use ipv6 && use ssl ; then
+		myconf=(
+			USE_CRYPTO=$(usex openssl)
+			USE_GCRYPT=$(usex gcrypt)
+			USE_NETTLE=$(usex nettle)
+		)
 	fi
 }
 
@@ -95,11 +101,9 @@ src_compile() {
 	emake \
 		USE_CAP=$(usex caps) \
 		USE_IDN=$(usex idn) \
-		USE_GCRYPT=$(usex gcrypt) \
-		USE_CRYPTO=$(usex ssl) \
-		LDFLAG_RESOLV=$(ldflag_resolv) \
-		IPV4_TARGETS="${IPV4_TARGETS[*]}" \
-		IPV6_TARGETS="${IPV6_TARGETS[*]}"
+		IPV4_DEFAULT=$(usex ipv6 'no' 'yes') \
+		TARGETS="${TARGETS[*]}" \
+		${myconf[@]}
 
 	if [[ ${PV} == "99999999" ]] ; then
 		emake html man
@@ -108,8 +112,12 @@ src_compile() {
 
 src_install() {
 	into /
-	dobin ping $(usex ipv6 'ping6' '')
-	use ipv6 && dosym ping.8 /usr/share/man/man8/ping6.8
+	dobin ping
+	dosym ping /bin/ping4
+	if use ipv6 ; then
+		dosym ping /bin/ping6
+		dosym ping.8 /usr/share/man/man8/ping6.8
+	fi
 	doman doc/ping.8
 
 	if use arping ; then
@@ -153,7 +161,6 @@ src_install() {
 pkg_postinst() {
 	fcaps cap_net_raw \
 		bin/ping \
-		$(usex ipv6 'bin/ping6' '') \
 		$(usex arping 'bin/arping' '') \
 		$(usex clockdiff 'usr/bin/clockdiff' '')
 }

--- a/net-misc/iputils/iputils-99999999.ebuild
+++ b/net-misc/iputils/iputils-99999999.ebuild
@@ -56,7 +56,7 @@ fi
 
 REQUIRED_USE="ipv6? ( ssl? ( ^^ ( gcrypt nettle openssl ) ) )"
 
-S=${WORKDIR}/${PN}-s${PV}
+[ "${PV}" = "99999999" ] || S="${WORKDIR}/${PN}-s${PV}"
 
 PATCHES=(
 	"${FILESDIR}/021109-uclibc-no-ether_ntohost.patch"
@@ -153,7 +153,7 @@ src_install() {
 		newconfd "${FILESDIR}"/rarpd.conf.d rarpd
 	fi
 
-	dodoc INSTALL RELNOTES
+	dodoc INSTALL.md RELNOTES
 
 	use doc && dohtml doc/*.html
 }

--- a/net-misc/iputils/iputils-99999999.ebuild
+++ b/net-misc/iputils/iputils-99999999.ebuild
@@ -58,12 +58,7 @@ REQUIRED_USE="ipv6? ( ssl? ( ^^ ( gcrypt nettle openssl ) ) )"
 
 [ "${PV}" = "99999999" ] || S="${WORKDIR}/${PN}-s${PV}"
 
-PATCHES=(
-	"${FILESDIR}/021109-uclibc-no-ether_ntohost.patch"
-)
-
 src_prepare() {
-	epatch ${PATCHES[@]}
 	use SECURITY_HAZARD && epatch "${FILESDIR}"/${PN}-20150815-nonroot-floodping.patch
 }
 


### PR DESCRIPTION
The current `net-misc/iputils-99999999` is no longer working and
needs the following changes:

 * Merge all important changes from `iputils-20160308.ebuild`
    - Switch upstream to `github.com/iputils/iputils`
    - Add nettle and openssl use flags
    - Remove obsolete patches
    - Adapt `src_configure()` and related functions
 * Don't use `S` variable when `PV=99999999`
 * Reflect the rename of `INSTALL` to `INSTALL.md`
 * Drop `021109-uclibc-no-ether_ntohost.patch` as latest uClibc in Gentoo
   already supports `ether_ntohost()` function.