### PR TITLE
sys-boot/grub: fix btrfs multi-device handling in grub-mkconfig

### DIFF
--- a/sys-boot/grub/files/2.02_beta3-grub-mkconfig-btrfs-multidev.patch
+++ b/sys-boot/grub/files/2.02_beta3-grub-mkconfig-btrfs-multidev.patch
@@ -1,0 +1,11 @@
+--- a/util/grub-mkconfig.in	2016-02-14 11:50:41.000000000 +0100
++++ b/util/grub-mkconfig.in	2017-06-11 18:26:43.898578691 +0200
+@@ -132,7 +132,7 @@
+ fi
+ 
+ # Device containing our userland.  Typically used for root= parameter.
+-GRUB_DEVICE="`${grub_probe} --target=device /`"
++GRUB_DEVICE="`${grub_probe} --target=device / | head -n 1`"
+ GRUB_DEVICE_UUID="`${grub_probe} --device ${GRUB_DEVICE} --target=fs_uuid 2> /dev/null`" || true
+ 
+ # Device containing our /boot partition.  Usually the same as GRUB_DEVICE.

--- a/sys-boot/grub/grub-2.02.ebuild
+++ b/sys-boot/grub/grub-2.02.ebuild
@@ -35,6 +35,7 @@ fi
 PATCHES=(
 	"${FILESDIR}"/gfxpayload.patch
 	"${FILESDIR}"/grub-2.02_beta2-KERNEL_GLOBS.patch
+	"${FILESDIR}"/2.02_beta3-grub-mkconfig-btrfs-multidev.patch
 )
 
 DEJAVU=dejavu-sans-ttf-2.37

--- a/sys-boot/grub/grub-2.02_beta3-r1.ebuild
+++ b/sys-boot/grub/grub-2.02_beta3-r1.ebuild
@@ -35,6 +35,7 @@ PATCHES=(
 	"${FILESDIR}"/2.02_beta3-10_linux-UUID.patch
 	"${FILESDIR}"/2.02_beta3-sysmacros.patch
 	"${FILESDIR}"/2.02_beta3-gcc6-ld-no-pie.patch
+	"${FILESDIR}"/2.02_beta3-grub-mkconfig-btrfs-multidev.patch
 )
 
 DEJAVU=dejavu-sans-ttf-2.35

--- a/sys-boot/grub/grub-2.02_rc1.ebuild
+++ b/sys-boot/grub/grub-2.02_rc1.ebuild
@@ -35,6 +35,7 @@ fi
 PATCHES=(
 	"${FILESDIR}"/gfxpayload.patch
 	"${FILESDIR}"/grub-2.02_beta2-KERNEL_GLOBS.patch
+	"${FILESDIR}"/2.02_beta3-grub-mkconfig-btrfs-multidev.patch
 )
 
 DEJAVU=dejavu-sans-ttf-2.37

--- a/sys-boot/grub/grub-2.02_rc2.ebuild
+++ b/sys-boot/grub/grub-2.02_rc2.ebuild
@@ -35,6 +35,7 @@ fi
 PATCHES=(
 	"${FILESDIR}"/gfxpayload.patch
 	"${FILESDIR}"/grub-2.02_beta2-KERNEL_GLOBS.patch
+	"${FILESDIR}"/2.02_beta3-grub-mkconfig-btrfs-multidev.patch
 )
 
 DEJAVU=dejavu-sans-ttf-2.37


### PR DESCRIPTION
Gentoo-Bug: 581904

Package-Manager: Portage-2.3.6, Repoman-2.3.1