### PR TITLE
Remove old twisted-names and twisted-core.

### DIFF
--- a/dev-python/python-msrplib/python-msrplib-0.18.0.ebuild
+++ b/dev-python/python-msrplib/python-msrplib-0.18.0.ebuild
@@ -21,6 +21,5 @@ RDEPEND="
 	dev-python/python-application[${PYTHON_USEDEP}]
 	dev-python/python-eventlib[${PYTHON_USEDEP}]
 	dev-python/python-gnutls[${PYTHON_USEDEP}]
-	dev-python/twisted-core[${PYTHON_USEDEP}]
-	dev-python/twisted-names[${PYTHON_USEDEP}]
+	dev-python/twisted[${PYTHON_USEDEP}]
 "


### PR DESCRIPTION
Remove old twisted-names and twisted-core dependencies as
upstream moved to single package distribution.

Signed-off-by: José Pekkarinen <koalinux@gmail.com>