### PR TITLE
Add release event status mask patch to xbindkeys

### DIFF
--- a/x11-misc/xbindkeys/files/xbindkeys-apply-mask-on-release-event-status.patch
+++ b/x11-misc/xbindkeys/files/xbindkeys-apply-mask-on-release-event-status.patch
@@ -1,0 +1,28 @@
+commit ceb7093f8d77cf5952e8e7778db02a6f3e8d8872
+Author: Alberto <address@hidden>
+Date:   Mon Feb 10 09:21:57 2014 +0200
+
+    fix keyboard layout problems
+
+diff --git a/xbindkeys.c b/xbindkeys.c
+index b0adef9..162e47e 100644
+--- a/xbindkeys.c
++++ b/xbindkeys.c
+@@ -377,7 +377,7 @@ event_loop (Display * d)
+ 	      printf ("e.xbutton.state=%d\n", e.xbutton.state);
+ 	    }
+ 
+-	  e.xbutton.state &= ~(numlock_mask | capslock_mask | scrolllock_mask
++	  e.xbutton.state &= 0x1FFF && ~(numlock_mask | capslock_mask | scrolllock_mask
+ 			       | Button1Mask | Button2Mask | Button3Mask
+ 			       | Button4Mask | Button5Mask);
+ 
+@@ -409,7 +409,7 @@ event_loop (Display * d)
+ 	      printf ("e.xbutton.state=%d\n", e.xbutton.state);
+ 	    }
+ 
+-	  e.xbutton.state &= ~(numlock_mask | capslock_mask | scrolllock_mask
++	  e.xbutton.state &= 0x1FFF && ~(numlock_mask | capslock_mask | scrolllock_mask
+ 			       | Button1Mask | Button2Mask | Button3Mask
+ 			       | Button4Mask | Button5Mask);
+ 

--- a/x11-misc/xbindkeys/xbindkeys-1.8.6-r1.ebuild
+++ b/x11-misc/xbindkeys/xbindkeys-1.8.6-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+DESCRIPTION="Tool for launching commands on keystrokes"
+SRC_URI="http://www.nongnu.org/${PN}/${P}.tar.gz"
+HOMEPAGE="http://www.nongnu.org/xbindkeys/xbindkeys.html"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64 ~arm ppc ppc64 sparc x86 ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris"
+IUSE="guile tk"
+
+RDEPEND="x11-libs/libX11
+	guile? ( >=dev-scheme/guile-1.8.4[deprecated] )
+	tk? ( dev-lang/tk )"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+PATCHES=(
+
+	"${FILESDIR}/${PN}-apply-mask-on-release-event-status.patch"
+)
+
+src_configure() {
+	econf \
+		$(use_enable tk) \
+		$(use_enable guile)
+}

--- a/x11-misc/xbindkeys/xbindkeys-1.8.6-r1.ebuild
+++ b/x11-misc/xbindkeys/xbindkeys-1.8.6-r1.ebuild
@@ -19,7 +19,6 @@ DEPEND="${RDEPEND}
 	x11-base/xorg-proto"
 
 PATCHES=(
-
 	"${FILESDIR}/${PN}-apply-mask-on-release-event-status.patch"
 )
 


### PR DESCRIPTION
Add and make apply a patch to x11-misc/xbindkeys, which
applies mask to release event status fixing layout issues
(please, see https://askubuntu.com/a/825622 and
https://lists.nongnu.org/archive/html/xbindkeys-devel/2014-02/msg00002.html).
The patch is actually merged to xbindkeys upstream, but
no new version is released since then.

Fixes Gentoo bug report [#548000](https://bugs.gentoo.org/548000).